### PR TITLE
Allowing concurrent read in Regex.Deserialize

### DIFF
--- a/srm/Regex.cs
+++ b/srm/Regex.cs
@@ -94,7 +94,7 @@ namespace Microsoft.SRM
         /// <returns></returns>
         public static Regex Deserialize(string file, IFormatter formatter = null)
         {
-            Stream stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.None);
+            Stream stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read);
             Regex matcher = Deserialize(stream, formatter);
             stream.Close();
             return matcher;


### PR DESCRIPTION
This prevents tools that use this library from re-using the same regex file concurrently. Using FileShare.Read seems like still a fairly conservative option that allows concurrent execution.